### PR TITLE
Fix unicode handling

### DIFF
--- a/japanese/notetypes.py
+++ b/japanese/notetypes.py
@@ -1,5 +1,5 @@
-"""
 -*- coding: utf-8 -*-
+"""
 Author: RawToast
 License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 


### PR DESCRIPTION
Python is not seeing the utf-8 encoding directive because it is within a block comment.